### PR TITLE
Patch a bug when you fail drugs processing

### DIFF
--- a/server/sv_processing.lua
+++ b/server/sv_processing.lua
@@ -350,7 +350,7 @@ RegisterNetEvent('it-drugs:server:processDrugs', function(data)
     if failChance <= recipe.failChance then
         ShowNotification(source, _U('NOTIFICATION__PROCESS__FAIL'), 'error')
         for k,v in pairs(recipe.ingrediants) do
-            it.removeItem(source, k, v)
+            it.removeItem(source, k, v.amount)
         end
         return
     end


### PR DESCRIPTION
Hi,

When you fail drugs processing, the items are not deleted, and we got an error in the server console
Here is the patch